### PR TITLE
Python 3 migration

### DIFF
--- a/src/mapcss/Eval.py
+++ b/src/mapcss/Eval.py
@@ -72,7 +72,7 @@ class Eval():
                 pass
         """
         try:
-            return str(eval(self.expr, {}, {
+            result = eval(self.expr, {}, {
                             "tag": lambda x: tags.get(x, ""),
                             "prop": lambda x: props.get(x, ""),
                             "num": m_num,
@@ -84,7 +84,20 @@ class Eval():
                             "max": m_max,
                             "cond": m_cond,
                             "boolean": m_boolean
-                            }))
+                            })
+            if type(result) == float:
+                # In Python2 and Python3 float to string behaves differently
+                # Python 2:
+                #   >>> str(2.8 + 0.4)
+                #   '3.2'
+                # Python 3:
+                #   >>> str(2.8 + 0.4)
+                #   '3.1999999999999997'
+                #
+                # See https://stackoverflow.com/q/25898733 for details
+                return "{:.4g}".format(result)
+
+            return str(result)
         except:
             return ""
 

--- a/src/mapcss/__init__.py
+++ b/src/mapcss/__init__.py
@@ -170,12 +170,12 @@ class MapCSS():
             return colors[0].styles[0]
         return None
 
-    def get_style_dict(self, clname, type, tags={}, zoom=0, xscale=1, zscale=.5, olddict={}, filter_by_runtime_conditions=None):
+    def get_style_dict(self, clname, type, tags={}, zoom=0, xscale=1, zscale=.5, olddict=None, filter_by_runtime_conditions=None):
         """
         Kothic styling API
         """
         r = self.get_style(clname, type, tags, zoom, xscale, zscale, filter_by_runtime_conditions)
-        d = olddict
+        d = olddict or dict()
         for x in r:
             if x.get('object-id', '') not in d:
                 d[x.get('object-id', '')] = {}


### PR DESCRIPTION
Fixed multiprocessing.
Added explicit data sorting.
Fixed float to string conversion.
Fixed explicit ordering of styles.

## Compare to baseline
I compared this branch output to commit #cbaff545dd5d2343dcbd30285884dd4afa509d93 output.
Styles `clear/style-clear`, `clear/style-night`, `vehicle/style-clear`, and `vehicle/style-night` processed with Python2 and Python3 generated same output `drules_proto_clear.txt`, `drules_proto_dark.txt`, `drules_proto_vehicle_clear.txt`, and `drules_proto_vehicle_dark.txt`.

I sorted elements by priority to compare Python2 and Python3 outputs.

One difference is in float representation. In Python3 we have `4.2700000000000005` instead of `4.27`. Here's discussion: https://stackoverflow.com/q/25898733 . This should not affect binary format created with ProtoBuf.

Please do comparing of old and new implementation because I could miss some cases!

## Refactoring
Don't get me wrong, but code quality is far from best. There are a lot of places in `libkomwm.py` where code execution depends on order of styles. But in Python3 `dict` order is not the same as in Python2. And even more, `dict` doesn't guaranty ordering. So I put `OrderedDict` to freeze dict elements positions which looks like a hack.

I think unit-tests are needed and then refactoring.