### PR TITLE
Add casing-width-add support

### DIFF
--- a/src/libkomwm.py
+++ b/src/libkomwm.py
@@ -359,18 +359,19 @@ def komap_mapswithme(options):
                         if has_lines and not is_area_st and st.get('casing-linecap', 'butt') == 'butt':
                             dr_line = LineRuleProto()
 
-                            # 'casing-width' has precedence over 'casing-width-add'.
-                            if st.get('casing-width-add') is not None and st.get('casing-width') in (None, 0):
-                                # Look for base width in other style objects (usually ::default).
-                                base_width = 0
+                            base_width = st.get('width', 0)
+                            if base_width == 0:
                                 for wst in zstyle:
                                     if wst.get('width') not in (None, 0):
                                         # Rail bridge styles use width from ::dash object instead of ::default.
                                         if base_width == 0 or wst.get('object-id') != '::default':
                                             base_width = wst.get('width', 0)
-                                st['casing-width'] = base_width + st.get('casing-width-add')
+                                # 'casing-width' has precedence over 'casing-width-add'.
+                                if st.get('casing-width') in (None, 0):
+                                    st['casing-width'] = base_width + st.get('casing-width-add')
+                                    base_width = 0
 
-                            dr_line.width = round((st.get('width', 0) + st.get('casing-width') * 2) * WIDTH_SCALE, 2)
+                            dr_line.width = round((base_width + st.get('casing-width') * 2) * WIDTH_SCALE, 2)
                             dr_line.color = mwm_encode_color(colors, st, "casing")
                             if '-x-me-casing-line-priority' in st:
                                 dr_line.priority = int(st.get('-x-me-casing-line-priority'))

--- a/src/mapcss/Condition.py
+++ b/src/mapcss/Condition.py
@@ -75,7 +75,7 @@ class Condition:
         t = self.type
         params = self.params
         if t == 'eq' and params[0][:2] == "::":
-            return "::%s" % (params[1])
+            return "%s" % (params[1])
         if t == 'eq':
             return "%s=%s" % (params[0], params[1])
         if t == 'ne':

--- a/src/mapcss/StyleChooser.py
+++ b/src/mapcss/StyleChooser.py
@@ -277,9 +277,6 @@ class StyleChooser:
                             b = str(float(b) / 2)
                         except:
                             pass
-                if "text" == a[-4:]:
-                    if b[:5] != "eval(":
-                        b = "eval(tag(\"" + b + "\"))"
                 if b[:5] == "eval(":
                     b = Eval(b)
                     self.has_evals = True

--- a/src/mapcss/__init__.py
+++ b/src/mapcss/__init__.py
@@ -22,7 +22,7 @@ from .StyleChooser import StyleChooser
 from .Condition import Condition
 
 
-NEEDED_KEYS = set(["width", "casing-width", "fill-color", "fill-image", "icon-image", "text", "extrude",
+NEEDED_KEYS = set(["width", "casing-width", "casing-width-add", "fill-color", "fill-image", "icon-image", "text", "extrude",
                    "background-image", "background-color", "pattern-image", "shield-text", "symbol-shape"])
 
 WHITESPACE = re.compile(r'\s+ ', re.S | re.X)


### PR DESCRIPTION
To be able to use e.g.
```
{casing-width-add: 1;}

```
instead of 
```
{casing-width: eval(prop("width")+1);}
```

To solve issue with eval()'s use https://github.com/organicmaps/organicmaps/issues/4258
and to simplify mapcss files' syntax too.