### PR TITLE
Make per-tag sets of selectors more precise and small

### DIFF
--- a/src/libkomwm.py
+++ b/src/libkomwm.py
@@ -231,10 +231,11 @@ def komap_mapswithme(options):
     # Build optimization tree - class/type -> StyleChoosers
     for cl in class_order:
         clname = cl if cl.find('-') == -1 else cl[:cl.find('-')]
-        cltags = classificator[cl]
-        style.build_choosers_tree(clname, "line", cltags)
-        style.build_choosers_tree(clname, "area", cltags)
-        style.build_choosers_tree(clname, "node", cltags)
+        # Get first tag of the class/type.
+        cltag = next(iter(classificator[cl].keys()))
+        style.build_choosers_tree(clname, "line", cltag)
+        style.build_choosers_tree(clname, "area", cltag)
+        style.build_choosers_tree(clname, "node", cltag)
     style.restore_choosers_order("line")
     style.restore_choosers_order("area")
     style.restore_choosers_order("node")

--- a/src/mapcss/Rule.py
+++ b/src/mapcss/Rule.py
@@ -59,10 +59,12 @@ class Rule():
     def extract_tags(self):
         a = set()
         for condition in self.conditions:
-            a.add(condition.extract_tag())
-            if "*" in a:
-                a = set(["*"])
-                break
+            tag = condition.extract_tag()
+            if tag != '*':
+                a.add(tag)
+            elif len(a) == 0:
+                return set(["*"])
+
         return a
 
 

--- a/src/mapcss/__init__.py
+++ b/src/mapcss/__init__.py
@@ -112,7 +112,7 @@ class MapCSS():
         else:
             logging.error("unparsed zoom: %s" % s)
 
-    def build_choosers_tree(self, clname, type, tags={}):
+    def build_choosers_tree(self, clname, type, cltag):
         if type not in self.choosers_by_type_and_tag:
             self.choosers_by_type_and_tag[type] = {}
         if clname not in self.choosers_by_type_and_tag[type]:
@@ -120,7 +120,7 @@ class MapCSS():
         if type in self.choosers_by_type:
             for chooser in self.choosers_by_type[type]:
                 for tag in chooser.extract_tags():
-                    if tag == "*" or tag in tags:
+                    if tag == "*" or tag == cltag:
                         if chooser not in self.choosers_by_type_and_tag[type][clname]:
                             self.choosers_by_type_and_tag[type][clname].add(chooser)
                         break


### PR DESCRIPTION
Makes styles compilation ~1.7 times faster (one minute vs 1:45 on my laptop).

Also inadvertently fixes tourism-information-office icon issue https://github.com/organicmaps/organicmaps/pull/4312

ATM for each primary tag (e.g. `highway`, `historic`, `office` etc.) we build a list of style selectors/rules that potentially apply to an OM type that starts from this primary tag (e.g. `highway-path`). ATM this list includes many selectors which obviously can't apply to a given tag, e.g. for `highway` tag there were selectors like `[route=ski]` and `[railway][bridge?]::bridgewhite`.

This patch makes selectors filtering more precise and thus reduces number of rules to try apply to each OM type.
E.g. it reduces number of selectors for `line|highway` from 353 to 306, for `node|office` from 107 to 8, for `node|shop` from from 250 to 140, etc.

The https://github.com/organicmaps/organicmaps/pull/4312 fix happens because the `[office]` selector is not added anymore into a `tourism` selectors list and thus is not applied to the `tourism-information-office` type which is right.

There are no changes to compiled styles other than this fix.