### PR TITLE
Require protobuf 3.21+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-protobuf~=4.23.0
+# The core is using protobuf 3.3.0 still (3party/protobuf/), so no point to require newer versions.
+# E.g. Ubuntu 24.04 LTS ships with python3-protobuf 3.21.12 and it works fine.
+protobuf~=3.21.0


### PR DESCRIPTION
There is no point to require 4.23 as the core uses 3.3.0 still.

E.g. Ubuntu 24.04 LTS ships with python3-protobuf 3.21.12 and it works fine (probably works with lower versions too).

4.23 requirement was added when only the kothic part (https://github.com/organicmaps/kothic/pull/15) of the https://github.com/organicmaps/organicmaps/pull/5557 was merged.

@AndrewShkrob